### PR TITLE
DialogFlow API v2との互換性のためにコードを更新します

### DIFF
--- a/ChomadoVoice/GoogleHome.cs
+++ b/ChomadoVoice/GoogleHome.cs
@@ -25,9 +25,6 @@ namespace ChomadoVoice
             try
             {
                 log.Info("C# HTTP trigger function processed a request.");
-                var json = await req.Content.ReadAsStringAsync();
-                log.Info("Json received: ", json);
-                var data2 = Models.DialogFlowRequestModel.FromJson(json);
                 var data = await req.Content.ReadAsAsync<Models.DialogFlowRequestModel>();
                 //log.Info(data);
                 var say = data.QueryResult.QueryText;
@@ -48,7 +45,7 @@ namespace ChomadoVoice
 
                 // Azure Blob Storage に書き込まれた mp3 にアクセスするための URL
                 var mp3Url = mp3Out.Uri;
-                //At least with DialogFlow v2, webhook responses from here back to DialogFlow now need to be in a standard format. 
+                //DialogFlow v2 では、DialogFlow へのwebhookの応答メッセージ　標準データ形式である必要がある。
                 //See https://developers.google.com/assistant/actions/build/json/dialogflow-webhook-json and https://cloud.google.com/dialogflow/docs/reference/rpc/google.cloud.dialogflow.v2#webhookresponse
                 var response = new Models.DialogFlowResponseModel
                 {

--- a/ChomadoVoice/GoogleHome.cs
+++ b/ChomadoVoice/GoogleHome.cs
@@ -59,6 +59,8 @@ namespace ChomadoVoice
             catch (Exception ex)
             {
                 log.Error("An exception occurred in GoogleHome.Run", ex);
+                var result = req.CreateErrorResponse(HttpStatusCode.InternalServerError, ex);
+                return result;
             }
         }
         

--- a/ChomadoVoice/GoogleHome.cs
+++ b/ChomadoVoice/GoogleHome.cs
@@ -56,7 +56,7 @@ namespace ChomadoVoice
                     {
                         Google = new Models.Google
                         {
-                            ExpectUserResponse = true,
+                            ExpectUserResponse = false,
                             RichResponse = new Models.RichResponse
                             {
                                 Items = new Models.Item[]

--- a/ChomadoVoice/GoogleHome.cs
+++ b/ChomadoVoice/GoogleHome.cs
@@ -25,6 +25,7 @@ namespace ChomadoVoice
             try
             {
                 log.Info("C# HTTP trigger function processed a request.");
+                var json = await req.Content.ReadAsStringAsync();
                 var data = await req.Content.ReadAsAsync<Models.DialogFlowResponseModel>();
                 //log.Info(data);
                 var say = data.Result.ResolvedQuery;

--- a/ChomadoVoice/GoogleHome.cs
+++ b/ChomadoVoice/GoogleHome.cs
@@ -26,9 +26,11 @@ namespace ChomadoVoice
             {
                 log.Info("C# HTTP trigger function processed a request.");
                 var json = await req.Content.ReadAsStringAsync();
-                var data = await req.Content.ReadAsAsync<Models.DialogFlowResponseModel>();
+                log.Info("Json received: ", json);
+                var data2 = Models.DialogFlowRequestModel.FromJson(json);
+                var data = await req.Content.ReadAsAsync<Models.DialogFlowRequestModel>();
                 //log.Info(data);
-                var say = data.Result.ResolvedQuery;
+                var say = data.QueryResult.QueryText;
 
                 // VoiceText Web API に投げる処理 test
                 var voiceTextClient = new VoiceTextClient

--- a/ChomadoVoice/GoogleHome.cs
+++ b/ChomadoVoice/GoogleHome.cs
@@ -26,7 +26,7 @@ namespace ChomadoVoice
             //log.Info(data);
             var say = data.Result.ResolvedQuery;
 
-            // VoiceText Web API に投げる処理
+            // VoiceText Web API に投げる処理 test
             var voiceTextClient = new VoiceTextClient
             {
                 APIKey = Keys.APIKeys.VoiceTextWebApiKey,

--- a/ChomadoVoice/GoogleHome.cs
+++ b/ChomadoVoice/GoogleHome.cs
@@ -48,14 +48,35 @@ namespace ChomadoVoice
 
                 // Azure Blob Storage に書き込まれた mp3 にアクセスするための URL
                 var mp3Url = mp3Out.Uri;
-
-                var result = req.CreateResponse(HttpStatusCode.OK, new
+                //At least with DialogFlow v2, webhook responses from here back to DialogFlow now need to be in a standard format. 
+                //See https://developers.google.com/assistant/actions/build/json/dialogflow-webhook-json and https://cloud.google.com/dialogflow/docs/reference/rpc/google.cloud.dialogflow.v2#webhookresponse
+                var response = new Models.DialogFlowResponseModel
                 {
-                    // Google Home に喋らせたい文言を渡す。（この場合mp3）
-                    speech = $"<speak><audio src='{mp3Url}' /></speak>",
-                    // Google Assistant のチャット画面上に出したい文字列
-                    displayText = $"「{say}」"
-                });
+                    Payload = new Models.Payload
+                    {
+                        Google = new Models.Google
+                        {
+                            ExpectUserResponse = true,
+                            RichResponse = new Models.RichResponse
+                            {
+                                Items = new Models.Item[]
+                                {
+                                    new Models.Item
+                                    {
+                                        SimpleResponse = new Models.SimpleResponse
+                                        {
+                                            // Google Home に喋らせたい文言を渡す。（この場合mp3）
+                                            SSML = $"<speak><audio src='{mp3Url}' /></speak>",
+                                            // Google Assistant のチャット画面上に出したい文字列
+                                            DisplayText = $"「{say}」"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+                var result = req.CreateResponse(HttpStatusCode.OK, response);
                 result.Headers.Add("ContentType", "application/json");
                 return result;
             }

--- a/ChomadoVoice/Keys/APIKeys.cs
+++ b/ChomadoVoice/Keys/APIKeys.cs
@@ -5,6 +5,8 @@ namespace ChomadoVoice.Keys
     class APIKeys
     {
         // ここに、VoiceTextWebApiで自分で取得したAPIキーを入れてね！
+        // 又は、以下の行を残し、AzureポータルのAzure Functionアプリケーション「アプリケーション設定」→「アプリケーション設定」でVoiceText APIキーを設定します。
+        // Environment.GetEnvironmentalVariable(...)は、ハードコーディングすることなく、この値を安全に参照します
         public static readonly string VoiceTextWebApiKey = Environment.GetEnvironmentVariable("VoiceTextWebApiKey");
     }
 }

--- a/ChomadoVoice/Keys/APIKeys.cs
+++ b/ChomadoVoice/Keys/APIKeys.cs
@@ -1,8 +1,10 @@
-﻿namespace ChomadoVoice.Keys
+﻿using System;
+
+namespace ChomadoVoice.Keys
 {
     class APIKeys
     {
         // ここに、VoiceTextWebApiで自分で取得したAPIキーを入れてね！
-        public static readonly string VoiceTextWebApiKey = "(WebAPIキーを記入)";
+        public static readonly string VoiceTextWebApiKey = Environment.GetEnvironmentVariable("VoiceTextWebApiKey");
     }
 }

--- a/ChomadoVoice/Models/DialogFlowResponseModel.cs
+++ b/ChomadoVoice/Models/DialogFlowResponseModel.cs
@@ -10,7 +10,7 @@
     public partial class DialogFlowRequestModel
     {
         [JsonProperty("responseId")]
-        public Guid ResponseId { get; set; }
+        public string ResponseId { get; set; }
 
         [JsonProperty("session")]
         public string Session { get; set; }

--- a/ChomadoVoice/Models/DialogFlowResponseModel.cs
+++ b/ChomadoVoice/Models/DialogFlowResponseModel.cs
@@ -103,7 +103,7 @@
         public static DialogFlowRequestModel FromJson(string json) => JsonConvert.DeserializeObject<DialogFlowRequestModel>(json, ChomadoVoice.Models.Converter.Settings);
     }
 
-    public static class Serialize
+    public static class SerializeRequest
     {
         public static string ToJson(this DialogFlowRequestModel self) => JsonConvert.SerializeObject(self, ChomadoVoice.Models.Converter.Settings);
     }
@@ -120,4 +120,130 @@
             },
         };
     }
+
+
+    public partial class DialogFlowResponseModel
+    {
+        [JsonProperty("fulfillmentText")]
+        public string FulfillmentText { get; set; }
+
+        [JsonProperty("fulfillmentMessages")]
+        public FulfillmentMessage[] FulfillmentMessages { get; set; }
+
+        [JsonProperty("source")]
+        public string Source { get; set; }
+
+        [JsonProperty("payload")]
+        public Payload Payload { get; set; }
+
+        [JsonProperty("outputContexts")]
+        public OutputContext[] OutputContexts { get; set; }
+
+        [JsonProperty("followupEventInput")]
+        public FollowupEventInput FollowupEventInput { get; set; }
+    }
+
+    public partial class FollowupEventInput
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("languageCode")]
+        public string LanguageCode { get; set; }
+
+        [JsonProperty("parameters")]
+        public Parameters Parameters { get; set; }
+    }
+
+    public partial class FulfillmentMessage
+    {
+        [JsonProperty("card")]
+        public Card Card { get; set; }
+    }
+
+    public partial class Card
+    {
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
+        [JsonProperty("subtitle")]
+        public string Subtitle { get; set; }
+
+        [JsonProperty("imageUri")]
+        public Uri ImageUri { get; set; }
+
+        [JsonProperty("buttons")]
+        public Button[] Buttons { get; set; }
+    }
+
+    public partial class Button
+    {
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+        [JsonProperty("postback")]
+        public Uri Postback { get; set; }
+    }
+
+    public partial class Payload
+    {
+        [JsonProperty("google")]
+        public Google Google { get; set; }
+
+        [JsonProperty("facebook")]
+        public Facebook Facebook { get; set; }
+
+        [JsonProperty("slack")]
+        public Facebook Slack { get; set; }
+    }
+
+    public partial class Facebook
+    {
+        [JsonProperty("text")]
+        public string Text { get; set; }
+    }
+
+    public partial class Google
+    {
+        [JsonProperty("expectUserResponse")]
+        public bool ExpectUserResponse { get; set; }
+
+        [JsonProperty("richResponse")]
+        public RichResponse RichResponse { get; set; }
+    }
+
+    public partial class RichResponse
+    {
+        [JsonProperty("items")]
+        public Item[] Items { get; set; }
+    }
+
+    public partial class Item
+    {
+        [JsonProperty("simpleResponse")]
+        public SimpleResponse SimpleResponse { get; set; }
+    }
+
+    public partial class SimpleResponse
+    {
+        [JsonProperty("textToSpeech")]
+        public string TextToSpeech { get; set; }
+
+        [JsonProperty("ssml")]
+        public string SSML { get; set; }
+
+        [JsonProperty("display_text")]
+        public string DisplayText { get; set; }
+    }
+
+    public partial class DialogFlowResponseModel
+    {
+        public static DialogFlowResponseModel FromJson(string json) => JsonConvert.DeserializeObject<DialogFlowResponseModel>(json, ChomadoVoice.Models.Converter.Settings);
+    }
+
+    public static class SerializeResponse
+    {
+        public static string ToJson(this DialogFlowResponseModel self) => JsonConvert.SerializeObject(self, ChomadoVoice.Models.Converter.Settings);
+    }
+
 }

--- a/ChomadoVoice/Models/DialogFlowResponseModel.cs
+++ b/ChomadoVoice/Models/DialogFlowResponseModel.cs
@@ -1,288 +1,121 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
-
-namespace ChomadoVoice.Models
+﻿namespace ChomadoVoice.Models
 {
-    /// <summary>
-    /// DialogFlow から渡ってくる JSON をパースする用
-    /// </summary>
-    public class DialogFlowResponseModel
+    using System;
+    using System.Collections.Generic;
+
+    using System.Globalization;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    public partial class DialogFlowRequestModel
     {
-        [JsonProperty("originalRequest")]
-        public OriginalRequest OriginalRequest { get; set; }
+        [JsonProperty("responseId")]
+        public Guid ResponseId { get; set; }
 
-        [JsonProperty("id")]
-        public string Id { get; set; }
+        [JsonProperty("session")]
+        public string Session { get; set; }
 
-        [JsonProperty("timestamp")]
-        public System.DateTimeOffset Timestamp { get; set; }
+        [JsonProperty("queryResult")]
+        public QueryResult QueryResult { get; set; }
 
-        [JsonProperty("lang")]
-        public string Lang { get; set; }
-
-        [JsonProperty("result")]
-        public Result Result { get; set; }
-
-        [JsonProperty("status")]
-        public Status Status { get; set; }
-
-        [JsonProperty("sessionId")]
-        public string SessionId { get; set; }
+        [JsonProperty("originalDetectIntentRequest")]
+        public OriginalDetectIntentRequest OriginalDetectIntentRequest { get; set; }
     }
 
-    public partial class OriginalRequest
+    public partial class OriginalDetectIntentRequest
     {
-        [JsonProperty("source")]
-        public string Source { get; set; }
-
-        [JsonProperty("version")]
-        public string Version { get; set; }
-
-        [JsonProperty("data")]
-        public Data Data { get; set; }
     }
 
-    public partial class Data
+    public partial class QueryResult
     {
-        [JsonProperty("isInSandbox")]
-        public bool IsInSandbox { get; set; }
+        [JsonProperty("queryText")]
+        public string QueryText { get; set; }
 
-        [JsonProperty("surface")]
-        public Urface Surface { get; set; }
+        [JsonProperty("parameters")]
+        public Parameters Parameters { get; set; }
 
-        [JsonProperty("inputs")]
-        public Input[] Inputs { get; set; }
+        [JsonProperty("allRequiredParamsPresent")]
+        public bool AllRequiredParamsPresent { get; set; }
 
-        [JsonProperty("user")]
-        public User User { get; set; }
+        [JsonProperty("fulfillmentText")]
+        public string FulfillmentText { get; set; }
 
-        [JsonProperty("conversation")]
-        public Conversation Conversation { get; set; }
+        [JsonProperty("fulfillmentMessages")]
+        public FulfillmentMessage[] FulfillmentMessages { get; set; }
 
-        [JsonProperty("availableSurfaces")]
-        public Urface[] AvailableSurfaces { get; set; }
-    }
-
-    public partial class Urface
-    {
-        [JsonProperty("capabilities")]
-        public Capability[] Capabilities { get; set; }
-    }
-
-    public partial class Capability
-    {
-        [JsonProperty("name")]
-        public string Name { get; set; }
-    }
-
-    public partial class Conversation
-    {
-        [JsonProperty("conversationId")]
-        public string ConversationId { get; set; }
-
-        [JsonProperty("type")]
-        public string Type { get; set; }
-
-        [JsonProperty("conversationToken")]
-        public string ConversationToken { get; set; }
-    }
-
-    public partial class Input
-    {
-        [JsonProperty("rawInputs")]
-        public RawInput[] RawInputs { get; set; }
-
-        [JsonProperty("arguments")]
-        public Argument[] Arguments { get; set; }
+        [JsonProperty("outputContexts")]
+        public OutputContext[] OutputContexts { get; set; }
 
         [JsonProperty("intent")]
-        public string Intent { get; set; }
+        public Intent Intent { get; set; }
+
+        [JsonProperty("intentDetectionConfidence")]
+        public long IntentDetectionConfidence { get; set; }
+
+        [JsonProperty("diagnosticInfo")]
+        public OriginalDetectIntentRequest DiagnosticInfo { get; set; }
+
+        [JsonProperty("languageCode")]
+        public string LanguageCode { get; set; }
     }
 
-    public partial class Argument
+    public partial class FulfillmentMessage
     {
-        [JsonProperty("rawText")]
-        public string RawText { get; set; }
+        [JsonProperty("text")]
+        public Text Text { get; set; }
+    }
 
-        [JsonProperty("textValue")]
-        public string TextValue { get; set; }
+    public partial class Text
+    {
+        [JsonProperty("text")]
+        public string[] TextText { get; set; }
+    }
 
+    public partial class Intent
+    {
         [JsonProperty("name")]
         public string Name { get; set; }
+
+        [JsonProperty("displayName")]
+        public string DisplayName { get; set; }
     }
 
-    public partial class RawInput
+    public partial class OutputContext
     {
-        [JsonProperty("query")]
-        public string Query { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-        [JsonProperty("inputType")]
-        public string InputType { get; set; }
-    }
-
-    public partial class User
-    {
-        [JsonProperty("lastSeen")]
-        public System.DateTimeOffset LastSeen { get; set; }
-
-        [JsonProperty("locale")]
-        public string Locale { get; set; }
-
-        [JsonProperty("userId")]
-        public string UserId { get; set; }
-    }
-
-    public partial class Result
-    {
-        [JsonProperty("source")]
-        public string Source { get; set; }
-
-        [JsonProperty("resolvedQuery")]
-        public string ResolvedQuery { get; set; }
-
-        [JsonProperty("speech")]
-        public string Speech { get; set; }
-
-        [JsonProperty("action")]
-        public string Action { get; set; }
-
-        [JsonProperty("actionIncomplete")]
-        public bool ActionIncomplete { get; set; }
+        [JsonProperty("lifespanCount")]
+        public long LifespanCount { get; set; }
 
         [JsonProperty("parameters")]
-        public ResultParameters Parameters { get; set; }
-
-        [JsonProperty("contexts")]
-        public Context[] Contexts { get; set; }
-
-        [JsonProperty("metadata")]
-        public Metadata Metadata { get; set; }
-
-        [JsonProperty("fulfillment")]
-        public Fulfillment Fulfillment { get; set; }
-
-        [JsonProperty("score")]
-        public double Score { get; set; }
+        public Parameters Parameters { get; set; }
     }
 
-    public partial class Context
+    public partial class Parameters
     {
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("parameters")]
-        public JObject Parameters { get; set; }
-
-        [JsonProperty("lifespan")]
-        public long Lifespan { get; set; }
-    }
-    
-    public partial class Fulfillment
-    {
-        [JsonProperty("speech")]
-        public string Speech { get; set; }
-
-        [JsonProperty("messages")]
-        public Message[] Messages { get; set; }
+        [JsonProperty("param")]
+        public string Param { get; set; }
     }
 
-    public partial class Message
+    public partial class DialogFlowRequestModel
     {
-        [JsonProperty("type")]
-        public long Type { get; set; }
-
-        [JsonProperty("speech")]
-        public string Speech { get; set; }
-    }
-
-    public partial class Metadata
-    {
-        [JsonProperty("matchedParameters")]
-        public MatchedParameter[] MatchedParameters { get; set; }
-
-        [JsonProperty("intentName")]
-        public string IntentName { get; set; }
-
-        [JsonProperty("isResponseToSlotfilling")]
-        public bool IsResponseToSlotfilling { get; set; }
-
-        [JsonProperty("intentId")]
-        public string IntentId { get; set; }
-
-        [JsonProperty("webhookUsed")]
-        public string WebhookUsed { get; set; }
-
-        [JsonProperty("webhookForSlotFillingUsed")]
-        public string WebhookForSlotFillingUsed { get; set; }
-
-        [JsonProperty("nluResponseTime")]
-        public long NluResponseTime { get; set; }
-    }
-
-    public partial class MatchedParameter
-    {
-        [JsonProperty("required")]
-        public bool Required { get; set; }
-
-        [JsonProperty("dataType")]
-        public string DataType { get; set; }
-
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
-        [JsonProperty("value")]
-        public string Value { get; set; }
-
-        [JsonProperty("isList")]
-        public bool IsList { get; set; }
-    }
-
-    public partial class ResultParameters
-    {
-        [JsonProperty("objective")]
-        public string Objective { get; set; }
-
-        [JsonProperty("Verb")]
-        public string Verb { get; set; }
-    }
-
-    public partial class Status
-    {
-        [JsonProperty("code")]
-        public long Code { get; set; }
-
-        [JsonProperty("errorType")]
-        public string ErrorType { get; set; }
-
-        [JsonProperty("webhookTimedOut")]
-        public bool WebhookTimedOut { get; set; }
-    }
-
-    public partial class Welcome
-    {
-        public static Welcome FromJson(string json) => JsonConvert.DeserializeObject<Welcome>(json, Converter.Settings);
+        public static DialogFlowRequestModel FromJson(string json) => JsonConvert.DeserializeObject<DialogFlowRequestModel>(json, ChomadoVoice.Models.Converter.Settings);
     }
 
     public static class Serialize
     {
-        public static string ToJson(this Welcome self) => JsonConvert.SerializeObject(self, Converter.Settings);
+        public static string ToJson(this DialogFlowRequestModel self) => JsonConvert.SerializeObject(self, ChomadoVoice.Models.Converter.Settings);
     }
 
-    internal class Converter
+    internal static class Converter
     {
         public static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
         {
             MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
             DateParseHandling = DateParseHandling.None,
-            Converters = {
+            Converters =
+            {
                 new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
             },
         };


### PR DESCRIPTION
@chomado ,

2019年10月23日に、GoogleはDialogFlowのV1 APIを廃止し、シャットダウンしました。このPRは、主にV2 APIと互換性があるようにコードを更新します。
また：

- GoogleHome.csで、DialogFlow応答モデルが初期化されて返されると、「Payload」プロパティはhttps://cloud.google.com/dialogflow/docs/reference/rpc/google.cloudにリストされているものに基づいています。 dialogflow.v2＃webhookresponse。しかし、「fulfillment_messages []」プロパティを使用してそれを記述するよりシンプルでクリーンな方法はありますか？

- 「APIKeys.cs」を変更しました - 環境変数からVoiceTextWebApiKeyを取得します。開発者がsatoshi-maemotoの記事に従い、VoiceTextWebApiKeyをAzure Portalの「アプリケーション設定」に追加すると、このコードが機能します。より安全な設計パターンです。ただし、Qiitaの記事に従う場合は、Environment.GetEnvironmentalVariable（...）をAPIキーに置き換える必要があります。これは大丈夫だと思いますか？

すみません、私の日本語はあまり上手ではありません.